### PR TITLE
Update url pattern

### DIFF
--- a/org.ferdium.Ferdium.yaml
+++ b/org.ferdium.Ferdium.yaml
@@ -66,7 +66,7 @@ modules:
           type: html
           url: https://github.com/ferdium/ferdium-app/releases/latest
           version-pattern: <a[^>]+>([\d\.]+\-beta\.\d+)?</a>
-          url-template: https://github.com/ferdium/ferdium-app/releases/download/v$version/ferdium_${version}_amd64.deb
+          url-template: https://github.com/ferdium/ferdium-app/releases/download/v$version/Ferdium-linux-${version}-amd64.deb
           sort-matches: false
       - type: file
         only-arches:
@@ -77,7 +77,7 @@ modules:
           type: html
           url: https://github.com/ferdium/ferdium-app/releases/latest
           version-pattern: <a[^>]+>([\d\.]+\-beta\.\d+)?</a>
-          url-template: https://github.com/ferdium/ferdium-app/releases/download/v$version/ferdium_${version}_arm64.deb
+          url-template: https://github.com/ferdium/ferdium-app/releases/download/v$version/Ferdium-linux-${version}-arm64.deb
           sort-matches: false
       - type: file
         url: https://github.com/ferdium/ferdium-app/archive/refs/tags/v6.0.0-beta.2.tar.gz


### PR DESCRIPTION
Following the renaming of the ferdium assets, the pattern has changed and thus the `url-template` values need to be updated. 

Current names is as follows for linux: `Ferdium-linux-${version}-${arch}.deb`.