### PR TITLE
Add xdg-config permission to fix dark theme

### DIFF
--- a/org.ferdium.Ferdium.yaml
+++ b/org.ferdium.Ferdium.yaml
@@ -16,6 +16,7 @@ finish-args:
   - --device=all
   - --filesystem=home:ro
   - --filesystem=xdg-download
+  - --filesystem=xdg-config/gtk-3.0:ro
   - --filesystem=/run/.heim_org.h5l.kcm-socket
   # For correct cursor scaling under Wayland
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons


### PR DESCRIPTION
I noticed that by default this app is not themed correctly on my system. This additional permission should resolve the broken theming on some systems.

Tested on my system:
Theme: Breeze Dark (org.gtk.Gtk3theme.Breeze)
Operating System: Arch Linux
KDE Plasma Version: 5.27.7
KDE Frameworks Version: 5.108.0
Qt Version: 5.15.10
Kernel Version: 6.4.9-arch1-1 (64-bit)
Graphics Platform: Wayland