### PR TITLE
Drop `org.kde.*` own-name

### DIFF
--- a/org.ferdium.Ferdium.yaml
+++ b/org.ferdium.Ferdium.yaml
@@ -22,7 +22,6 @@ finish-args:
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --own-name=org.kde.*
 modules:
   - name: krb5
     subdir: src


### PR DESCRIPTION
This is no longer required with newer Electron and runtime

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement
> but known exceptions to this are Electron versions older than 23.3.0.

Current version uses Electron 25.5.0
https://github.com/ferdium/ferdium-app/blob/09ee519fa30d2c3b12b820c33df6ec85a35ccf36/package.json#L163