### PR TITLE
Add ozone variable for using wayland

### DIFF
--- a/org.ferdium.Ferdium.yaml
+++ b/org.ferdium.Ferdium.yaml
@@ -20,7 +20,7 @@ finish-args:
   - --filesystem=/run/.heim_org.h5l.kcm-socket
   # For correct cursor scaling under Wayland
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
-  - --env=OZONE=x11
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=x11
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=com.canonical.AppMenu.Registrar
@@ -96,6 +96,6 @@ modules:
         dest-filename: ferdium.sh
         commands:
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
-          - exec zypak-wrapper /app/Ferdium/ferdium --ozone-platform-hint=$OZONE "$@"
+          - exec zypak-wrapper /app/Ferdium/ferdium --ozone-platform-hint=$ELECTRON_OZONE_PLATFORM_HINT "$@"
       - type: file
         path: org.ferdium.Ferdium.metainfo.xml

--- a/org.ferdium.Ferdium.yaml
+++ b/org.ferdium.Ferdium.yaml
@@ -10,6 +10,7 @@ rename-desktop-file: ferdium.desktop
 rename-icon: ferdium
 finish-args:
   - --socket=x11
+  - --socket=wayland
   - --share=ipc
   - --socket=pulseaudio
   - --share=network
@@ -19,6 +20,7 @@ finish-args:
   - --filesystem=/run/.heim_org.h5l.kcm-socket
   # For correct cursor scaling under Wayland
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
+  - --env=OZONE=x11
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=com.canonical.AppMenu.Registrar
@@ -94,6 +96,6 @@ modules:
         dest-filename: ferdium.sh
         commands:
           - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
-          - exec zypak-wrapper /app/Ferdium/ferdium "$@"
+          - exec zypak-wrapper /app/Ferdium/ferdium --ozone-platform-hint=$OZONE "$@"
       - type: file
         path: org.ferdium.Ferdium.metainfo.xml


### PR DESCRIPTION
By now the Ferdium flatpak only runs on x11. However, Ferdium has Wayland support, as shown in the snap package: https://github.com/ferdium/ferdium-app/blob/e21ec2976c8ddfdd3420b677d3347cddf5f6977a/electron-builder.yml#L13

It is possible to run the flatpak in wayland by providing the same `--ozone-platform-hint` using flatpak run or by modifying the desktop file. However, the latter won't survive any updates.
Also fixes #44 

This PR introduces two things:
1. Enable the wayland socket, so Ferdium can talk to it
2. Add variable for `--ozone-platform-hint`. By default it is set to `x11` but setting it to `wayland` lets Ferdium run in wayland.

Edit: Imho this would be an easy and failsave way to get started on wayland. If wayland shall become the default on wayland desktops, `$OZONE` would only have to be replaced with `$XDG_SESSION_TYPE`.