### PR TITLE
Allow media controls to work

### DIFF
--- a/org.ferdium.Ferdium.yaml
+++ b/org.ferdium.Ferdium.yaml
@@ -24,6 +24,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=com.canonical.AppMenu.Registrar
+  - --own-name=org.mpris.MediaPlayer2.chromium.*
 modules:
   - name: krb5
     subdir: src


### PR DESCRIPTION
When playing music in the Ferdium app, it doesn't show up in the system notification area and the media keys on the keyboard cannot be used to control the music.
This additional permission fixes the issue.